### PR TITLE
Be more specific in defining deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "url": "https://github.com/urish/gulp-add-src/issues"
   },
   "dependencies": {
-    "vinyl-fs": "*",
     "event-stream": "~3.1.5",
-    "through2": "~0.4.1"
+    "through2": "~0.4.1",
+    "vinyl-fs": "~0.3.11"
   },
   "devDependencies": {
     "mocha": "^1.18.2",


### PR DESCRIPTION
It may not make a huge difference as `vinyl-fs` is in pre-1.0, but it makes me nervous to see a `*` in a dependency.
