### PR TITLE
Add `append()` and `prepend()` methods for controlling added files position

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ gulp.task('build', function () {
 });
 ```
 
+The order of files when the streams are merged is not guaranteed. If you need to preserve order and specifically append/prepend files,  you can use `addsrc.append` and `addsrc.prepend`, respectively, in place of just `addsrc` in the example above.
+
+As an example, this would be useful if you wanted to merge your `bower` scripts with your app scripts. You'd need your `bower` scripts to maintain their order (the `bower` scripts themselves) and make sure they come before your app scripts. In this case, you'd use `addsrc.prepend`.
+
+Because of the unpredicabilty of `addsrc` alone, it's recommended to use one of the append/prepend variants. The original is only left in place for legacy reasons.
+
 License
 ----
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "url": "https://github.com/urish/gulp-add-src/issues"
   },
   "dependencies": {
-    "vinyl-fs": "*",
     "event-stream": "~3.1.5",
-    "through2": "~0.4.1"
+    "streamqueue": "^0.1.1",
+    "through2": "~0.4.1",
+    "vinyl-fs": "*"
   },
   "devDependencies": {
     "mocha": "^1.18.2",

--- a/test.js
+++ b/test.js
@@ -17,12 +17,55 @@ describe('gulp-add-src', function () {
 			allFiles.push(file.path);
 		});
 		stream.on('end', function() {
+			// they just need to be the same, order doesn't matter!
+			assert.deepEqual(allFiles.sort(), [
+				join(__dirname, 'index.js'),
+				join(__dirname, 'test.js'),
+				join(__dirname, 'package.json'),
+				join(__dirname, 'README.md')
+			].sort());
+			done();
+		});
+	});
+
+	it('should append files to an existing stream in order', function (done) {
+		var stream = gulp.src(['index.js', 'test.js'])
+			.pipe(addsrc.append(['package.json', 'README.md']));
+
+		var allFiles = [];
+		stream.on('error', done);
+		stream.on('data', function (file) {
+			allFiles.push(file.path);
+		});
+		stream.on('end', function() {
+			// they just need to be the same, order doesn't matter!
 			assert.deepEqual(allFiles, [
 				join(__dirname, 'index.js'),
 				join(__dirname, 'test.js'),
 				join(__dirname, 'package.json'),
 				join(__dirname, 'README.md')
 			]);
+			done();
+		});
+	});
+
+	it('should append files to an existing stream in order', function (done) {
+		var stream = gulp.src(['index.js', 'test.js'])
+			.pipe(addsrc.append(['package.json', 'README.md']));
+
+		var allFiles = [];
+		stream.on('error', done);
+		stream.on('data', function (file) {
+			allFiles.push(file.path);
+		});
+		stream.on('end', function() {
+			// they just need to be the same, order doesn't matter!
+			assert.deepEqual(allFiles.sort(), [
+				join(__dirname, 'package.json'),
+				join(__dirname, 'README.md'),
+				join(__dirname, 'index.js'),
+				join(__dirname, 'test.js')
+			].sort());
 			done();
 		});
 	});


### PR DESCRIPTION
I had the intentions of adding the ability to knowingly append and prepend a stream (honoring the order of the individual stream definitions), and that's what I did. But what I didn't expect is when I first pulled down the repo, `npm test` failed. It seems that the order when the streams are combined is not preserved, and it's not predictable how they might output. It's possible a dependency (i.e. `vinyl`) changed how it behaves to remove any sort of predictability (see #3)?

Anyway, I tweaked that test and added the ability to append and prepend files and maintain order within themselves (and added tests for those and updated the README).

Oh, and all this business about `gulp.src` doing this instead and this plugin isn't needed anymore (see #1)... seems to be hogwash? It doesn't seem to work at all. Maybe it's a bug or we're all missing something?
