### PR TITLE
Note that Vinyl was upgraded in 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.0 - 2018-03-28
-- Make node 8 LTS compatible ([#15](https://github.com/urish/gulp-add-src/pull/15))
+- Upgrade Vinyl for Node 8 LTS compatibility ([#15](https://github.com/urish/gulp-add-src/pull/15))
 
 ## 0.2.0 - 2014-11-08
 


### PR DESCRIPTION
This detail actually ended up being pretty important for me when moving to Gulp 4, so mention it explicitly in the changelog.